### PR TITLE
Add CHANGELOG and release automation

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,3 @@
+1. Make a vx.y.z tag for the next release based on CHANGELOG.md and push it to origin.
+2. Use pbcopy to copy the relevant release notes from CHANGELOG.md to the clipboard.
+3. Bump the patch version, commit, and push that to main, updating CHANGELOG.md with the new section.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+<!-- loosely based on https://keepachangelog.com/en/1.0.0/ -->
+
+## Unreleased
+
+## 0.1.0 - 2025-01-13
+
+### Added
+
+- Initial release of CI Monitor
+- GitHub CI workflow monitoring with real-time status updates
+- Support for targeting commits, branches, and pull requests
+- Step-level failure detection without downloading entire logs
+- Smart log filtering showing only error-related content
+- Real-time CI status polling with fail-fast options (`--poll`, `--poll-until-failure`)
+- Raw log access for deep debugging (`--raw-logs`, `--job-id`)
+- Cross-platform support (Ubuntu, macOS) with Python 3.10+
+- Modern packaging with hatchling and UV dependency management
+- Comprehensive CLI with mutual exclusivity validation
+- PyPI publishing automation with trusted publishing
+- Automated version bumping with git tagging


### PR DESCRIPTION
- Add CHANGELOG.md following keepachangelog format
- Add .claude/commands/release.md for manual release workflow
- Document initial 0.1.0 release with comprehensive feature list
- Complete persistproc-style release automation setup

🤖 Generated with [Claude Code](https://claude.ai/code)