### PR TITLE
Restructure CLI to use clear subcommands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,26 +12,26 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-    
+
     runs-on: ${{ matrix.os }}
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
-      
+
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
-      
+
       - name: Install dependencies
         run: uv sync --extra dev
-      
+
       - name: Run tests
         run: uv run pytest --cov=cimonitor --cov-report=xml -v
-      
+
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         uses: codecov/codecov-action@v5
@@ -41,51 +41,51 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
-      
+
       - name: Set up Python
         run: uv python install 3.13
-      
+
       - name: Install dependencies
         run: uv sync --extra dev
-      
+
       - name: Run ruff check
         run: uv run ruff check .
-      
+
       - name: Run ruff format check
         run: uv run ruff format --check .
 
   cli-test:
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
-      
+
       - name: Set up Python
         run: uv python install 3.13
-      
+
       - name: Install dependencies
         run: uv sync
-      
+
       - name: Test CLI help command
         run: uv run cimonitor --help
-      
+
       - name: Test CLI with invalid options (should fail gracefully)
         run: |
           # Test mutual exclusivity validation
-          output=$(uv run cimonitor --commit abc123 --branch main 2>&1 || true)
+          output=$(uv run cimonitor status --commit abc123 --branch main 2>&1 || true)
           if echo "$output" | grep -q "Please specify only one"; then
             echo "✅ Mutual exclusivity validation works"
           else

--- a/README.md
+++ b/README.md
@@ -10,17 +10,18 @@ CI Monitor is a command-line tool that lets AI agents and humans instantly acces
 
 ```bash
 # Single command to investigate and fix your PR's CI failures
-cimonitor --pr 123 --logs | claude "Analyze these CI failures and fix the issues. Commit and push the fixes when done."
+cimonitor logs --pr 123 | claude \
+  "Analyze these CI failures and fix the issues. Commit and push the fixes when done."
 
 # Auto-retry flaky tests and get notified only for real failures
-cimonitor --pr 123 --watch-and-retry 3 | claude "Monitor this output. If tests still fail after retries, analyze the logs and notify me with a summary of the real issues."
+cimonitor watch --pr 123 --retry 3 | claude \
+  "Monitor this output. If tests still fail after retries, analyze the logs and notify me with a summary of the real issues."
 ```
 
 This powerful combination lets you:
+- **Stay Focused**: No need to monitor job status and engage with an agent if you see a failure—let the agent do the waiting
 - **Fix Real Issues**: Claude Code automatically parses CI logs, identifies root causes, implements fixes, and pushes solutions
 - **Handle Flaky Tests**: Auto-retry failing jobs up to N times, only getting notified if failures persist
-- **Smart Notifications**: Get intelligent summaries of actual problems, not transient flakes
-- **Zero Manual Work**: No copying error messages or switching between terminal and browser
 
 ## Installation
 
@@ -29,31 +30,38 @@ pip install cimonitor
 export GITHUB_TOKEN="your_github_token_here"
 ```
 
+How to generate a token:
+1. Visit [https://github.com/settings/tokens](https://github.com/settings/tokens),
+2. "Generate new token" -> "Generate new token (classic)"
+3. Check "repo" and "workflow"
+4. Generate the token and export it as an environment variable as shown above
+
 ## Usage
 
 ```bash
-# Check current branch
-cimonitor
+# Check CI status
+cimonitor status                    # Current branch
+cimonitor status --pr 123          # Specific PR
+cimonitor status --commit abc1234  # Specific commit
 
-# Target specific commits/branches/PRs
-cimonitor --commit abc1234 --logs
-cimonitor --branch main --verbose
-cimonitor --pr 123
+# Get error logs
+cimonitor logs                      # Current branch (filtered logs)
+cimonitor logs --pr 123            # PR logs
+cimonitor logs --raw               # Raw unfiltered logs
+cimonitor logs --job-id 12345678   # Specific job logs
 
-# Real-time monitoring
-cimonitor --watch-until-completion  # Wait for completion
-cimonitor --watch-until-fail        # Stop on first failure
-cimonitor --watch-and-retry 3       # Watch and auto-retry failed jobs up to 3 times
-
-# Debug specific jobs
-cimonitor --job-id 12345678 --raw-logs
+# Watch CI progress
+cimonitor watch                     # Watch current branch
+cimonitor watch --until-complete   # Wait for completion
+cimonitor watch --until-fail       # Stop on first failure
+cimonitor watch --retry 3          # Auto-retry failed jobs up to 3 times
 ```
 
 ## What Agents Can Do
 
 **Instant CI Diagnosis** - Check any commit, branch, or PR for failures and get structured output perfect for programmatic analysis.
 
-**Real-Time Monitoring** - Use `--watch-until-completion` to watch CI progress live, `--watch-until-fail` for fail-fast workflows, or `--watch-and-retry N` to automatically retry failed jobs and filter out flaky test failures.
+**Real-Time Monitoring** - Use `watch --until-complete` to watch CI progress live, `watch --until-fail` for fail-fast workflows, or `watch --retry N` to automatically retry failed jobs and filter out flaky test failures.
 
 **Targeted Debugging** - Get step-level failure details and filtered error logs without downloading massive raw logs.
 

--- a/cimonitor/cli.py
+++ b/cimonitor/cli.py
@@ -10,275 +10,85 @@ from .fetcher import GitHubCIFetcher
 from .log_parser import LogParser
 
 
-@click.command()
-@click.option(
-    "--branch", default=None, help="Specific branch to check (defaults to current branch)"
-)
-@click.option("--commit", help="Specific commit SHA to check")
-@click.option("--pr", "--pull-request", type=int, help="Pull request number to check")
+# Shared options for targeting commits/PRs/branches
+def target_options(f):
+    """Decorator to add common targeting options."""
+    f = click.option("--branch", help="Specific branch to check (defaults to current branch)")(f)
+    f = click.option("--commit", help="Specific commit SHA to check")(f)
+    f = click.option("--pr", "--pull-request", type=int, help="Pull request number to check")(f)
+    return f
+
+
+def validate_target_options(branch, commit, pr):
+    """Validate mutually exclusive target options."""
+    target_options = [branch, commit, pr]
+    specified_options = [opt for opt in target_options if opt is not None]
+    if len(specified_options) > 1:
+        click.echo("Error: Please specify only one of --branch, --commit, or --pr", err=True)
+        sys.exit(1)
+
+
+def get_target_info(fetcher, branch, commit, pr, verbose=False):
+    """Get target commit SHA and description from options."""
+
+    # Get repository info
+    owner, repo_name = fetcher.get_repo_info()
+    if verbose:
+        click.echo(f"Repository: {owner}/{repo_name}")
+
+    # Determine target commit SHA and description
+    if pr:
+        commit_sha = fetcher.get_pr_head_sha(owner, repo_name, pr)
+        target_description = f"PR #{pr}"
+        if verbose:
+            click.echo(f"Pull Request: #{pr}")
+            click.echo(f"Head commit: {commit_sha}")
+    elif commit:
+        commit_sha = fetcher.resolve_commit_sha(owner, repo_name, commit)
+        target_description = f"commit {commit[:8] if len(commit) >= 8 else commit}"
+        if verbose:
+            click.echo(f"Commit: {commit}")
+            click.echo(f"Resolved SHA: {commit_sha}")
+    elif branch:
+        commit_sha = fetcher.get_branch_head_sha(owner, repo_name, branch)
+        target_description = f"branch {branch}"
+        if verbose:
+            click.echo(f"Branch: {branch}")
+            click.echo(f"Head commit: {commit_sha}")
+    else:
+        # Default: use current branch and commit
+        current_branch, commit_sha = fetcher.get_current_branch_and_commit()
+        target_description = f"current branch ({current_branch})"
+        if verbose:
+            click.echo(f"Branch: {current_branch}")
+            click.echo(f"Latest commit: {commit_sha}")
+
+    return owner, repo_name, commit_sha, target_description
+
+
+@click.group(invoke_without_command=True)
+@click.version_option()
+@click.pass_context
+def cli(ctx):
+    """CI Monitor - Monitor GitHub CI workflows, fetch logs, and track build status."""
+    if ctx.invoked_subcommand is None:
+        # Default to status command when no subcommand is provided
+        ctx.invoke(status)
+
+
+@cli.command()
+@target_options
 @click.option("--verbose", "-v", is_flag=True, help="Show verbose output")
-@click.option("--logs", is_flag=True, help="Show filtered error logs for failed steps only")
-@click.option(
-    "--raw-logs", is_flag=True, help="Show complete raw logs for all failed jobs (for debugging)"
-)
-@click.option("--job-id", type=int, help="Show raw logs for specific job ID only")
-@click.option(
-    "--watch-until-completion", is_flag=True, help="Poll CI status until all workflows complete"
-)
-@click.option(
-    "--watch-until-fail", is_flag=True, help="Poll CI status until first failure or all complete"
-)
-@click.option(
-    "--watch-and-retry",
-    type=int,
-    metavar="COUNT",
-    help="Poll and automatically retry failed jobs up to COUNT times",
-)
-def main(
-    branch: str | None,
-    commit: str | None,
-    pr: int | None,
-    verbose: bool,
-    logs: bool,
-    raw_logs: bool,
-    job_id: int | None,
-    watch_until_completion: bool,
-    watch_until_fail: bool,
-    watch_and_retry: int | None,
-):
-    """Fetch GitHub CI logs for failing builds.
-
-    Target options (--branch, --commit, --pr) are mutually exclusive.
-    If none specified, uses current branch and latest commit.
-    """
-
+def status(branch, commit, pr, verbose):
+    """Show CI status for the target commit/branch/PR."""
     try:
-        # Validate options (do this first, before any API calls)
-        target_options = [branch, commit, pr]
-        specified_options = [opt for opt in target_options if opt is not None]
-        if len(specified_options) > 1:
-            click.echo("Error: Please specify only one of --branch, --commit, or --pr", err=True)
-            sys.exit(1)
-
-        if watch_until_completion and watch_until_fail:
-            click.echo(
-                "Error: Cannot specify both --watch-until-completion and --watch-until-fail",
-                err=True,
-            )
-            sys.exit(1)
-
-        if watch_and_retry is not None and watch_and_retry < 1:
-            click.echo("Error: --watch-and-retry must be a positive integer", err=True)
-            sys.exit(1)
-
-        if watch_and_retry and (watch_until_completion or watch_until_fail):
-            click.echo(
-                "Error: Cannot specify --watch-and-retry with other watch options (watch-and-retry includes polling)",
-                err=True,
-            )
-            sys.exit(1)
+        # Validate options first, before any API calls
+        validate_target_options(branch, commit, pr)
 
         fetcher = GitHubCIFetcher()
-
-        # Get repository info
-        owner, repo_name = fetcher.get_repo_info()
-        if verbose:
-            click.echo(f"Repository: {owner}/{repo_name}")
-
-        # Determine target commit SHA and description
-        if pr:
-            commit_sha = fetcher.get_pr_head_sha(owner, repo_name, pr)
-            target_description = f"PR #{pr}"
-            if verbose:
-                click.echo(f"Pull Request: #{pr}")
-                click.echo(f"Head commit: {commit_sha}")
-        elif commit:
-            commit_sha = fetcher.resolve_commit_sha(owner, repo_name, commit)
-            target_description = f"commit {commit[:8] if len(commit) >= 8 else commit}"
-            if verbose:
-                click.echo(f"Commit: {commit}")
-                click.echo(f"Resolved SHA: {commit_sha}")
-        elif branch:
-            commit_sha = fetcher.get_branch_head_sha(owner, repo_name, branch)
-            target_description = f"branch {branch}"
-            if verbose:
-                click.echo(f"Branch: {branch}")
-                click.echo(f"Head commit: {commit_sha}")
-        else:
-            # Default: use current branch and commit
-            current_branch, commit_sha = fetcher.get_current_branch_and_commit()
-            target_description = f"current branch ({current_branch})"
-            if verbose:
-                click.echo(f"Branch: {current_branch}")
-                click.echo(f"Latest commit: {commit_sha}")
-
-        # Handle polling options
-        if watch_until_completion or watch_until_fail or watch_and_retry:
-            click.echo(f"🔄 Polling CI status for {target_description}...")
-            click.echo(f"📋 Commit: {commit_sha}")
-            if watch_and_retry:
-                click.echo(f"🔁 Will retry failed jobs up to {watch_and_retry} time(s)")
-            click.echo("Press Ctrl+C to stop polling\n")
-
-            poll_interval = 10  # seconds
-            max_polls = 120  # 20 minutes total
-            poll_count = 0
-            retry_count = 0
-
-            try:
-                while poll_count < max_polls:
-                    workflow_runs = fetcher.get_workflow_runs_for_commit(
-                        owner, repo_name, commit_sha
-                    )
-
-                    if not workflow_runs:
-                        click.echo("⏳ No workflow runs found yet...")
-                    else:
-                        click.echo(f"📊 Found {len(workflow_runs)} workflow run(s):")
-
-                        all_completed = True
-                        any_failed = False
-                        failed_runs = []
-
-                        for run in workflow_runs:
-                            name = run.get("name", "Unknown Workflow")
-                            status = run.get("status", "unknown")
-                            conclusion = run.get("conclusion")
-                            created_at = run.get("created_at", "")
-                            updated_at = run.get("updated_at", "")
-                            run_id = run.get("id")
-
-                            # Calculate duration
-                            try:
-                                start = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
-                                if updated_at:
-                                    end = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
-                                else:
-                                    end = datetime.now(start.tzinfo)
-                                duration = end - start
-                                duration_str = f"{int(duration.total_seconds())}s"
-                            except Exception:
-                                duration_str = "unknown"
-
-                            # Status emoji and tracking
-                            if status == "completed":
-                                if conclusion == "success":
-                                    emoji = "✅"
-                                elif conclusion == "failure":
-                                    emoji = "❌"
-                                    any_failed = True
-                                    failed_runs.append(run_id)
-                                elif conclusion == "cancelled":
-                                    emoji = "🚫"
-                                    any_failed = True
-                                    failed_runs.append(run_id)
-                                else:
-                                    emoji = "⚠️"
-                                    any_failed = True
-                                    failed_runs.append(run_id)
-                            elif status == "in_progress":
-                                emoji = "🔄"
-                                all_completed = False
-                            elif status == "queued":
-                                emoji = "⏳"
-                                all_completed = False
-                            else:
-                                emoji = "❓"
-                                all_completed = False
-
-                            click.echo(f"  {emoji} {name} ({status}) - {duration_str}")
-
-                        # Check stopping conditions
-                        if watch_until_fail and any_failed:
-                            click.echo("\n💥 Stopping on first failure!")
-                            sys.exit(1)
-
-                        if all_completed:
-                            if any_failed and watch_and_retry and retry_count < watch_and_retry:
-                                retry_count += 1
-                                click.echo(
-                                    f"\n🔁 Retrying failed jobs (attempt {retry_count}/{watch_and_retry})..."
-                                )
-
-                                # Retry failed runs
-                                for run_id in failed_runs:
-                                    if fetcher.rerun_failed_jobs(owner, repo_name, run_id):
-                                        click.echo(f"  ✅ Restarted failed jobs in run {run_id}")
-                                    else:
-                                        click.echo(f"  ❌ Failed to restart jobs in run {run_id}")
-
-                                # Reset polling for the retry
-                                poll_count = 0
-                                time.sleep(30)  # Wait a bit longer before starting to poll again
-                                continue
-                            elif any_failed:
-                                if watch_and_retry and retry_count >= watch_and_retry:
-                                    click.echo(
-                                        f"\n💥 Max retries ({watch_and_retry}) reached. Some workflows still failed!"
-                                    )
-                                else:
-                                    click.echo("\n💥 Some workflows failed!")
-                                sys.exit(1)
-                            else:
-                                click.echo("\n🎉 All workflows completed successfully!")
-                                sys.exit(0)
-
-                    if poll_count < max_polls - 1:  # Don't sleep on last iteration
-                        click.echo(
-                            f"\n⏰ Waiting {poll_interval}s... (poll {poll_count + 1}/{max_polls})"
-                        )
-                        time.sleep(poll_interval)
-
-                    poll_count += 1
-
-                click.echo("\n⏰ Polling timeout reached")
-                sys.exit(1)
-
-            except KeyboardInterrupt:
-                click.echo("\n👋 Polling stopped by user")
-                sys.exit(0)
-
-        # Handle specific job ID request
-        if job_id:
-            click.echo(f"📄 Raw logs for job ID {job_id}:")
-            click.echo("=" * 80)
-            job_info = fetcher.get_job_by_id(owner, repo_name, job_id)
-            click.echo(f"Job: {job_info.get('name', 'Unknown')}")
-            click.echo(f"Status: {job_info.get('conclusion', 'unknown')}")
-            click.echo(f"URL: {job_info.get('html_url', '')}")
-            click.echo("-" * 80)
-            logs = fetcher.get_job_logs(owner, repo_name, job_id)
-            click.echo(logs)
-            return
-
-        # Handle raw logs for all failed jobs
-        if raw_logs:
-            all_jobs = fetcher.get_all_jobs_for_commit(owner, repo_name, commit_sha)
-            failed_jobs = [job for job in all_jobs if job.get("conclusion") == "failure"]
-
-            if not failed_jobs:
-                click.echo("✅ No failing jobs found for this commit!")
-                return
-
-            click.echo(f"📄 Raw logs for {len(failed_jobs)} failed job(s):")
-            click.echo()
-
-            for i, job in enumerate(failed_jobs, 1):
-                job_name = job.get("name", "Unknown")
-                job_id = job.get("id")
-
-                click.echo(f"{'=' * 80}")
-                click.echo(f"RAW LOGS #{i}: {job_name} (ID: {job_id})")
-                click.echo(f"{'=' * 80}")
-
-                if job_id:
-                    logs = fetcher.get_job_logs(owner, repo_name, job_id)
-                    click.echo(logs)
-                else:
-                    click.echo("No job ID available")
-
-                click.echo("\n" + "=" * 80 + "\n")
-            return
+        owner, repo_name, commit_sha, target_description = get_target_info(
+            fetcher, branch, commit, pr, verbose
+        )
 
         # Find failed jobs for the target commit
         failed_check_runs = fetcher.find_failed_jobs_in_latest_run(owner, repo_name, commit_sha)
@@ -311,13 +121,12 @@ def main(
                     for job in jobs:
                         if job.get("conclusion") == "failure":
                             job_name = job.get("name", "Unknown")
-                            job_id = job.get("id")
 
-                            # Show failed steps summary first
+                            # Show failed steps summary
                             failed_steps = fetcher.get_failed_steps(job)
 
                             if failed_steps:
-                                click.echo(f"\n📋 Failed Steps in {job_name}:")
+                                click.echo(f"\\n📋 Failed Steps in {job_name}:")
                                 for step in failed_steps:
                                     step_name = step["name"]
                                     step_num = step["number"]
@@ -336,49 +145,150 @@ def main(
                                         f"  ❌ Step {step_num}: {step_name} (took {duration})"
                                     )
 
-                                click.echo()
+                            click.echo()
+                except Exception as e:
+                    click.echo(f"Error processing job details: {e}")
+            else:
+                click.echo("Cannot retrieve detailed information for this check run type")
 
-                            # Only show detailed logs if requested
-                            if logs:
-                                if job_id:
-                                    logs = fetcher.get_job_logs(owner, repo_name, job_id)
+            click.echo()
 
-                                    # Extract logs for just the failed steps
-                                    step_logs = LogParser.extract_step_logs(logs, failed_steps)
+    except ValueError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(f"Unexpected error: {e}", err=True)
+        sys.exit(1)
 
-                                    if step_logs:
-                                        for step_name, step_log in step_logs.items():
-                                            click.echo(f"\n📄 Logs for Failed Step: {step_name}")
-                                            click.echo("-" * 50)
 
-                                            # Show only the step-specific logs
-                                            if step_log.strip():
-                                                # Still filter for error-related content within the step
-                                                shown_lines = LogParser.filter_error_lines(step_log)
+@cli.command()
+@target_options
+@click.option("--verbose", "-v", is_flag=True, help="Show verbose output")
+@click.option("--raw", is_flag=True, help="Show complete raw logs (for debugging)")
+@click.option("--job-id", type=int, help="Show logs for specific job ID only")
+def logs(branch, commit, pr, verbose, raw, job_id):
+    """Show error logs for failed CI jobs."""
+    try:
+        # Validate options first, before any API calls
+        validate_target_options(branch, commit, pr)
 
-                                                if shown_lines:
-                                                    for line in shown_lines:
-                                                        if line.strip():
-                                                            click.echo(line)
-                                                else:
-                                                    # Fallback to last few lines of the step
-                                                    step_lines = step_log.split("\n")
-                                                    for line in step_lines[-10:]:
-                                                        if line.strip():
-                                                            click.echo(line)
+        fetcher = GitHubCIFetcher()
+        owner, repo_name, commit_sha, target_description = get_target_info(
+            fetcher, branch, commit, pr, verbose
+        )
+
+        # Handle specific job ID request
+        if job_id:
+            click.echo(f"📄 Raw logs for job ID {job_id}:")
+            click.echo("=" * 80)
+            job_info = fetcher.get_job_by_id(owner, repo_name, job_id)
+            click.echo(f"Job: {job_info.get('name', 'Unknown')}")
+            click.echo(f"Status: {job_info.get('conclusion', 'unknown')}")
+            click.echo(f"URL: {job_info.get('html_url', '')}")
+            click.echo("-" * 80)
+            logs_content = fetcher.get_job_logs(owner, repo_name, job_id)
+            click.echo(logs_content)
+            return
+
+        # Handle raw logs for all failed jobs
+        if raw:
+            all_jobs = fetcher.get_all_jobs_for_commit(owner, repo_name, commit_sha)
+            failed_jobs = [job for job in all_jobs if job.get("conclusion") == "failure"]
+
+            if not failed_jobs:
+                click.echo("✅ No failing jobs found for this commit!")
+                return
+
+            click.echo(f"📄 Raw logs for {len(failed_jobs)} failed job(s):")
+            click.echo()
+
+            for i, job in enumerate(failed_jobs, 1):
+                job_name = job.get("name", "Unknown")
+                job_id = job.get("id")
+
+                click.echo(f"{'=' * 80}")
+                click.echo(f"RAW LOGS #{i}: {job_name} (ID: {job_id})")
+                click.echo(f"{'=' * 80}")
+
+                if job_id:
+                    logs_content = fetcher.get_job_logs(owner, repo_name, job_id)
+                    click.echo(logs_content)
+                else:
+                    click.echo("No job ID available")
+
+                click.echo("\\n" + "=" * 80 + "\\n")
+            return
+
+        # Default: show filtered error logs
+        failed_check_runs = fetcher.find_failed_jobs_in_latest_run(owner, repo_name, commit_sha)
+
+        if not failed_check_runs:
+            click.echo(f"✅ No failing CI jobs found for {target_description}!")
+            return
+
+        click.echo(
+            f"📄 Error logs for {len(failed_check_runs)} failing job(s) in {target_description}:"
+        )
+        click.echo()
+
+        for i, check_run in enumerate(failed_check_runs, 1):
+            name = check_run.get("name", "Unknown Job")
+            html_url = check_run.get("html_url", "")
+
+            click.echo(f"{'=' * 60}")
+            click.echo(f"LOGS #{i}: {name}")
+            click.echo(f"{'=' * 60}")
+
+            # Try to get workflow run info and step details
+            if "actions/runs" in html_url:
+                try:
+                    # Extract run ID from URL
+                    run_id = html_url.split("/runs/")[1].split("/")[0]
+                    jobs = fetcher.get_workflow_jobs(owner, repo_name, int(run_id))
+
+                    for job in jobs:
+                        if job.get("conclusion") == "failure":
+                            job_name = job.get("name", "Unknown")
+                            job_id = job.get("id")
+
+                            # Get failed steps
+                            failed_steps = fetcher.get_failed_steps(job)
+
+                            if job_id and failed_steps:
+                                logs_content = fetcher.get_job_logs(owner, repo_name, job_id)
+
+                                # Extract logs for just the failed steps
+                                step_logs = LogParser.extract_step_logs(logs_content, failed_steps)
+
+                                if step_logs:
+                                    for step_name, step_log in step_logs.items():
+                                        click.echo(f"\\n📄 Logs for Failed Step: {step_name}")
+                                        click.echo("-" * 50)
+
+                                        # Show only the step-specific logs
+                                        if step_log.strip():
+                                            # Filter for error-related content within the step
+                                            shown_lines = LogParser.filter_error_lines(step_log)
+
+                                            if shown_lines:
+                                                for line in shown_lines:
+                                                    if line.strip():
+                                                        click.echo(line)
                                             else:
-                                                click.echo("No logs found for this step")
-                                    else:
-                                        click.echo(
-                                            f"\n📄 Could not extract step-specific logs for {job_name}"
-                                        )
-                                        click.echo("💡 This might be due to log format differences")
+                                                # Fallback to last few lines of the step
+                                                step_lines = step_log.split("\\n")
+                                                for line in step_lines[-10:]:
+                                                    if line.strip():
+                                                        click.echo(line)
+                                        else:
+                                            click.echo("No logs found for this step")
                                 else:
-                                    click.echo("Could not retrieve job logs")
+                                    click.echo(
+                                        f"\\n📄 Could not extract step-specific logs for {job_name}"
+                                    )
+                                    click.echo("💡 This might be due to log format differences")
                             else:
-                                click.echo(
-                                    "💡 Use --logs to see detailed error logs for failed steps only"
-                                )
+                                click.echo("Could not retrieve job logs")
 
                             click.echo()
 
@@ -395,3 +305,175 @@ def main(
     except Exception as e:
         click.echo(f"Unexpected error: {e}", err=True)
         sys.exit(1)
+
+
+@cli.command()
+@target_options
+@click.option("--verbose", "-v", is_flag=True, help="Show verbose output")
+@click.option("--until-complete", is_flag=True, help="Wait until all workflows complete")
+@click.option("--until-fail", is_flag=True, help="Stop on first failure")
+@click.option("--retry", type=int, metavar="COUNT", help="Auto-retry failed jobs up to COUNT times")
+def watch(branch, commit, pr, verbose, until_complete, until_fail, retry):
+    """Watch CI status with real-time updates."""
+    try:
+        # Validate options first, before any API calls
+        validate_target_options(branch, commit, pr)
+
+        # Validate watch options
+        if until_complete and until_fail:
+            click.echo("Error: Cannot specify both --until-complete and --until-fail", err=True)
+            sys.exit(1)
+
+        if retry is not None and retry < 1:
+            click.echo("Error: --retry must be a positive integer", err=True)
+            sys.exit(1)
+
+        if retry and (until_complete or until_fail):
+            click.echo(
+                "Error: Cannot specify --retry with other watch options (retry includes polling)",
+                err=True,
+            )
+            sys.exit(1)
+
+        fetcher = GitHubCIFetcher()
+        owner, repo_name, commit_sha, target_description = get_target_info(
+            fetcher, branch, commit, pr, verbose
+        )
+
+        click.echo(f"🔄 Watching CI status for {target_description}...")
+        click.echo(f"📋 Commit: {commit_sha}")
+        if retry:
+            click.echo(f"🔁 Will retry failed jobs up to {retry} time(s)")
+        click.echo("Press Ctrl+C to stop watching\\n")
+
+        poll_interval = 10  # seconds
+        max_polls = 120  # 20 minutes total
+        poll_count = 0
+        retry_count = 0
+
+        try:
+            while poll_count < max_polls:
+                workflow_runs = fetcher.get_workflow_runs_for_commit(owner, repo_name, commit_sha)
+
+                if not workflow_runs:
+                    click.echo("⏳ No workflow runs found yet...")
+                else:
+                    click.echo(f"📊 Found {len(workflow_runs)} workflow run(s):")
+
+                    all_completed = True
+                    any_failed = False
+                    failed_runs = []
+
+                    for run in workflow_runs:
+                        name = run.get("name", "Unknown Workflow")
+                        status = run.get("status", "unknown")
+                        conclusion = run.get("conclusion")
+                        created_at = run.get("created_at", "")
+                        updated_at = run.get("updated_at", "")
+                        run_id = run.get("id")
+
+                        # Calculate duration
+                        try:
+                            start = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+                            if updated_at:
+                                end = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+                            else:
+                                end = datetime.now(start.tzinfo)
+                            duration = end - start
+                            duration_str = f"{int(duration.total_seconds())}s"
+                        except Exception:
+                            duration_str = "unknown"
+
+                        # Status emoji and tracking
+                        if status == "completed":
+                            if conclusion == "success":
+                                emoji = "✅"
+                            elif conclusion == "failure":
+                                emoji = "❌"
+                                any_failed = True
+                                failed_runs.append(run_id)
+                            elif conclusion == "cancelled":
+                                emoji = "🚫"
+                                any_failed = True
+                                failed_runs.append(run_id)
+                            else:
+                                emoji = "⚠️"
+                                any_failed = True
+                                failed_runs.append(run_id)
+                        elif status == "in_progress":
+                            emoji = "🔄"
+                            all_completed = False
+                        elif status == "queued":
+                            emoji = "⏳"
+                            all_completed = False
+                        else:
+                            emoji = "❓"
+                            all_completed = False
+
+                        click.echo(f"  {emoji} {name} ({status}) - {duration_str}")
+
+                    # Check stopping conditions
+                    if until_fail and any_failed:
+                        click.echo("\\n💥 Stopping on first failure!")
+                        sys.exit(1)
+
+                    if all_completed:
+                        if any_failed and retry and retry_count < retry:
+                            retry_count += 1
+                            click.echo(
+                                f"\\n🔁 Retrying failed jobs (attempt {retry_count}/{retry})..."
+                            )
+
+                            # Retry failed runs
+                            for run_id in failed_runs:
+                                if fetcher.rerun_failed_jobs(owner, repo_name, run_id):
+                                    click.echo(f"  ✅ Restarted failed jobs in run {run_id}")
+                                else:
+                                    click.echo(f"  ❌ Failed to restart jobs in run {run_id}")
+
+                            # Reset polling for the retry
+                            poll_count = 0
+                            time.sleep(30)  # Wait a bit longer before starting to poll again
+                            continue
+                        elif any_failed:
+                            if retry and retry_count >= retry:
+                                click.echo(
+                                    f"\\n💥 Max retries ({retry}) reached. Some workflows still failed!"
+                                )
+                            else:
+                                click.echo("\\n💥 Some workflows failed!")
+                            sys.exit(1)
+                        else:
+                            click.echo("\\n🎉 All workflows completed successfully!")
+                            sys.exit(0)
+
+                if poll_count < max_polls - 1:  # Don't sleep on last iteration
+                    click.echo(
+                        f"\\n⏰ Waiting {poll_interval}s... (poll {poll_count + 1}/{max_polls})"
+                    )
+                    time.sleep(poll_interval)
+
+                poll_count += 1
+
+            click.echo("\\n⏰ Polling timeout reached")
+            sys.exit(1)
+
+        except KeyboardInterrupt:
+            click.echo("\\n👋 Watching stopped by user")
+            sys.exit(0)
+
+    except ValueError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(f"Unexpected error: {e}", err=True)
+        sys.exit(1)
+
+
+def main():
+    """Entry point for the CLI."""
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/mise.toml
+++ b/mise.toml
@@ -4,9 +4,9 @@ python = "3.13"  # Development version, supports 3.10+
 [env]
 _.file = ".env"
 
-[tasks.ci-logs]
-description = "Monitor CI status for the latest commit on current branch"
-run = "uv run cimonitor"
+[tasks.ci-status]
+description = "Check CI status for the latest commit on current branch"
+run = "uv run cimonitor status"
 
 [tasks.install]
 description = "Install dependencies"
@@ -44,9 +44,9 @@ run = "uv run pre-commit install"
 description = "Run pre-commit on all files"
 run = "uv run pre-commit run --all-files"
 
-[tasks.poll-ci]
-description = "Poll CI status for current commit"
-run = "uv run cimonitor --poll --verbose"
+[tasks.watch-ci]
+description = "Watch CI status for current commit"
+run = "uv run cimonitor watch --until-complete --verbose"
 
 [tasks.bump-version]
 description = "Bump version (--patch by default, supports --minor, --major)"


### PR DESCRIPTION
BREAKING CHANGE: Replace monolithic CLI with intuitive subcommands

- Add `cimonitor status` - Show CI status and failed steps summary
- Add `cimonitor logs` - Show filtered error logs from failed jobs
- Add `cimonitor watch` - Real-time monitoring with retry capabilities
- Maintain backward compatibility: `cimonitor` defaults to `status`
- Move validation before API calls for better error handling
- Update README examples to use new subcommand syntax
- Update GitHub Actions workflow and mise tasks for new structure

The new interface follows standard CLI conventions while preserving all existing functionality and improving usability.

🤖 Generated with [Claude Code](https://claude.ai/code)